### PR TITLE
Relate Cards

### DIFF
--- a/src/trello.coffee
+++ b/src/trello.coffee
@@ -146,7 +146,7 @@ relateCards = (msg, card_list) ->
 
 relateTheme = (msg, theme) ->
   msg.reply "Gathering cards for #{theme}"
-  trello.get "/1/search", {query: "is:open #{theme}",idBoards: board.id, modelTypes:"cards", card_fields: "name,shortLink,url"}, (err, data) -> 
+  trello.get "/1/search", {query: "is:open name:\"#{theme}\"",idBoards: board.id, modelTypes:"cards", card_fields: "name,shortLink,url"}, (err, data) -> 
     cardList = ''
     cardList = "#{cardList}#{card.shortLink}," for card in data.cards unless err
     msg.send "Error occured" if err


### PR DESCRIPTION
Also updated search functionality so that by default the board will only be searched by names of cards (not descriptions) 

Created functionality to "Relate Cards" this will take either a given list of cards, or search the name of cards for given criteria on the board. In either case the list of cards will then have their descriptions updated to have a "Related Cards" section that will have links to the other Trello cards that have been identified.

There is no current functionality to add or remove cards to this list (via hubot).
